### PR TITLE
Stomp Destination Header format override.

### DIFF
--- a/.Src/Stomp.Net/NMS.Stomp/Commands/Destination.cs
+++ b/.Src/Stomp.Net/NMS.Stomp/Commands/Destination.cs
@@ -46,6 +46,11 @@ namespace Stomp.Net.Stomp.Commands
 
         public String PhysicalName { get; } = String.Empty;
 
+        /// <summary>
+        /// Uses physical name property as stomp destination string without adding prefixes such as
+        /// queue or topic. This to support JMS brokers listening for queue/topic names in a different format.
+        /// </summary>
+        public Boolean SkipStompStringFormatting { get; set; }
         #endregion
 
         #region Ctor
@@ -159,6 +164,9 @@ namespace Stomp.Net.Stomp.Commands
         {
             if ( destination == null )
                 return null;
+
+            if (destination.SkipStompStringFormatting)
+                return destination.PhysicalName;
 
             String result;
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@
 *.user
 *.sln.docstates
 
+# Visual Studio cache/options directory
+.vs/
+
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/


### PR DESCRIPTION
Added property to allow usage of "raw" physicalname when creating the stomp destination header ignoring the prefix added in the ToStompString method. Once example for this use case is when resolving queue names for Wildfly 10 running artemis JMS queues where destination needs to be jms.queue.<queuename> without a /queue/ prefix.

Not the most elegant solution, but gets the job done and would be great if the update could be put into your repo enabling me to leverage the nuget package.