### PR TITLE
Allow to use custom transport with default connection factory and extend default transport factory

### DIFF
--- a/.Src/Stomp.Net/Connection/ConnectionFactory.cs
+++ b/.Src/Stomp.Net/Connection/ConnectionFactory.cs
@@ -23,11 +23,12 @@ public class ConnectionFactory : IConnectionFactory
     /// </summary>
     /// <param name="brokerUri">The broker URI.</param>
     /// <param name="stompConnectionSettings">The STOM connection settings.</param>
-    public ConnectionFactory( String brokerUri, StompConnectionSettings stompConnectionSettings )
+    /// <param name="transportFactory">The transport factory. If parameter is not provided the TransportFactory is used.</param>
+    public ConnectionFactory( String brokerUri, StompConnectionSettings stompConnectionSettings, ITransportFactory transportFactory = null )
     {
         BrokerUri = new(brokerUri);
         StompConnectionSettings = stompConnectionSettings;
-        _transportFactory = new TransportFactory( StompConnectionSettings );
+        _transportFactory = transportFactory ?? new TransportFactory( StompConnectionSettings );
     }
 
     #endregion


### PR DESCRIPTION
Current code composition not allow easily use custom transport without copying lot of code from current classes. Using two small changes in PR is posible to register custom transport like this:

```csharp
    public class StompCustomTransportFactory : StompTransportFactory
    {
        private readonly StompConnectionSettings _stompConnectionSettings;

        public StompCustomTransportFactory(StompConnectionSettings stompConnectionSettings) : base(stompConnectionSettings)
        {
            _stompConnectionSettings = stompConnectionSettings;
        }

        protected override ITransportFactory CreateTransportFactory(Uri location)
        {
            return location.Scheme.ToLower() switch
            {
                "ws" => new WebsocketTransportFactory(_stompConnectionSettings), // <-custom transport
                _ => base.CreateTransportFactory(location),
            };
        }
    }

    internal static class Program
    {
        [STAThread]
        private static void Main()

            var url = "ws://example.com/ws";
            var settings = new StompConnectionSettings()
            {
                // ...
            };
            var factory = new StompConnectionFactory(url, settings, new StompCustomTransportFactory(settings));
            // ...
        }
    }
```